### PR TITLE
en - New Login Page + some reworks

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,12 +1,12 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import HomePage from "main/pages/HomePage";
+import LoginPage from "main/pages/LoginPage";
 import ProfilePage from "main/pages/ProfilePage";
 
 import AdminUsersPage from "main/pages/AdminUsersPage";
 import AdminCreateCommonsPage from "main/pages/AdminCreateCommonsPage";
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import PlayPage from "main/pages/PlayPage"; 
-
 
 function App() {
 
@@ -15,7 +15,12 @@ function App() {
   return (
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<HomePage />} />
+          { 
+            (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) && <Route path="/" element={<HomePage />} />
+          }
+          { 
+            !(hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) && <Route path="/" element={<LoginPage />} />
+          }
           <Route path="/profile" element={<ProfilePage />} />
           {
             hasRole(currentUser, "ROLE_ADMIN") && <Route path="/admin/users" element={<AdminUsersPage />} />

--- a/frontend/src/fixtures/commonsFixtures.js
+++ b/frontend/src/fixtures/commonsFixtures.js
@@ -35,7 +35,66 @@ const commonsFixtures = {
                 "totalPlayers": 50,
                 "cowPrice": 15,
             }
-        ]
+        ],
+
+    sevenCommons: [
+        {
+            "id": 10,
+            "name": "Seths Commons",
+            "day": 5,
+            "endDate": "6/11/2021",
+            "totalPlayers": 50,
+            "cowPrice": 15,
+        },
+        {
+            "id": 8,
+            "name": "Kevin's Commons",
+            "day": 5,
+            "endDate": "6/11/2021",
+            "totalPlayers": 50,
+            "cowPrice": 15,
+        },
+        {
+            "id": 6,
+            "name": "Anika's Commons",
+            "day": 5,
+            "endDate": "6/11/2021",
+            "totalPlayers": 50,
+            "cowPrice": 15,
+        },
+        {
+            "id": 5,
+            "name": "Evan's Commons",
+            "day": 5,
+            "endDate": "6/11/2021",
+            "totalPlayers": 50,
+            "cowPrice": 15,
+        },
+        {
+            "id": 4,
+            "name": "Joshua's Commons",
+            "day": 5,
+            "endDate": "6/11/2021",
+            "totalPlayers": 50,
+            "cowPrice": 15,
+        },
+        {
+            "id": 3,
+            "name": "Danny's Commons",
+            "day": 5,
+            "endDate": "6/11/2021",
+            "totalPlayers": 50,
+            "cowPrice": 15,
+        },
+        {
+            "id": 2,
+            "name": "Jackson's Commons",
+            "day": 5,
+            "endDate": "6/11/2021",
+            "totalPlayers": 50,
+            "cowPrice": 15,
+        }
+    ],
 }
 
 export default commonsFixtures;

--- a/frontend/src/main/components/Commons/CommonsCard.js
+++ b/frontend/src/main/components/Commons/CommonsCard.js
@@ -8,7 +8,7 @@ const CommonsCard = (props) => {
                 <Row>
                     <Col sx={4} data-testid="commonsCard-id">{props.commons.id}</Col>
                     <Col sx={4} data-testid="commonsCard-name">{props.commons.name}</Col>
-                    {props.button != null && <Col sm={4}>{<Button data-testid={`commonsCard-button-${props.buttonText}-${props.commons.id}`} variant={'danger'} size="sm" className="mx-4" onClick={() => props.buttonLink(props.commons.id)} >{props.buttonText}</Button>}</Col>}
+                    {props.buttonText != null && <Col sm={4}><Button data-testid={`commonsCard-button-${props.buttonText}-${props.commons.id}`} variant={'danger'} size="sm" className="mx-4" onClick={() => props.buttonLink(props.commons.id)} >{props.buttonText}</Button></Col>}
                 </Row>
             </Container>
         </Card.Body>

--- a/frontend/src/main/components/Commons/CommonsCard.js
+++ b/frontend/src/main/components/Commons/CommonsCard.js
@@ -8,7 +8,7 @@ const CommonsCard = (props) => {
                 <Row>
                     <Col sx={4} data-testid="commonsCard-id">{props.commons.id}</Col>
                     <Col sx={4} data-testid="commonsCard-name">{props.commons.name}</Col>
-                    <Col sm={4}>{props.buttonText != null && <Button data-testid={`commonsCard-button-${props.buttonText}-${props.commons.id}`} variant={'danger'} size="sm" className="mx-4" onClick={() => props.buttonLink(props.commons.id)} >{props.buttonText}</Button>}</Col>
+                    {props.button != null && <Col sm={4}>{<Button data-testid={`commonsCard-button-${props.buttonText}-${props.commons.id}`} variant={'danger'} size="sm" className="mx-4" onClick={() => props.buttonLink(props.commons.id)} >{props.buttonText}</Button>}</Col>}
                 </Row>
             </Container>
         </Card.Body>

--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -5,7 +5,10 @@ import { Card, Container, Row, Col } from "react-bootstrap";
 const CommonsList = (props) => {
     return(
         <Card style={{opacity:".9"}} className="my-3 border-0">
-            <Card.Title data-testid="commonsList-title" style={{fontSize:"35px"}} className="text-center my-3">{props.buttonText} A Commons</Card.Title>
+            {//Why does it work like this? "A commons" is assumed to always be there - and we replace the verb...
+             //Changed in order to be used in other cases.
+            }
+            <Card.Title data-testid="commonsList-title" style={{fontSize:"35px"}} className="text-center my-3">{props.title}</Card.Title>
             <Card.Subtitle>
                 <Container>
                     <Row>

--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -5,9 +5,6 @@ import { Card, Container, Row, Col } from "react-bootstrap";
 const CommonsList = (props) => {
     return(
         <Card style={{opacity:".9"}} className="my-3 border-0">
-            {//Why does it work like this? "A commons" is assumed to always be there - and we replace the verb...
-             //Changed in order to be used in other cases.
-            }
             <Card.Title data-testid="commonsList-title" style={{fontSize:"35px"}} className="text-center my-3">{props.title}</Card.Title>
             <Card.Subtitle>
                 <Container>

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -67,8 +67,8 @@ export default function HomePage() {
         <h1 data-testid="homePage-title" style={{ fontSize: "75px", borderRadius: "7px", backgroundColor: "white", opacity: ".9" }} className="text-center border-0 my-3">Howdy Farmer</h1>
         <Container>
           <Row>
-            <Col sm><CommonsList commonList={commonsJoined} buttonText={"Visit"} buttonLink={visitButtonClick} /></Col>
-            <Col sm><CommonsList commonList={commons} buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
+            <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} /></Col>
+            <Col sm><CommonsList commonList={commons} title="Join A Commons" buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
           </Row>
         </Container>
       </BasicLayout>

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -15,7 +15,7 @@ export default function HomePage() {
 
   const queryClient = useQueryClient();
 
-  const { data: commons, error: commonError, status: commonStatus } = 
+  const { data: commons, error: commonsError, status: commonsStatus } = 
     useBackend(
       // Stryker disable next-line all : don't test internal caching of React Query
       ["/api/commons/all"],

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -16,15 +16,16 @@ export default function HomePage() {
 
   const queryClient = useQueryClient();
 
-  const { data: commonsFromBackend, error: commonsError, status: commonsStatus } =
+  const commonsFromBackend =
     useBackend(
       // Stryker disable next-line all : don't test internal caching of React Query
       ["/api/commons/all"],
       {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
         method: "GET",
         url: "/api/commons/all"
-      }
-    );
+      },
+      []
+    ).data;
 
   const objectToAxiosParams = (newCommonsId) => ({
     url: "/api/commons/join",

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -10,13 +10,12 @@ import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { useQueryClient } from "react-query";
 
 export default function HomePage() {
-  const [commons, setCommons] = useState([]);
   const [commonsJoined, setCommonsJoined] = useState([]);
   const { data: currentUser } = useCurrentUser();
 
   const queryClient = useQueryClient();
 
-  const commonsFromBackend =
+  const { data: commons, error: commonError, status: commonStatus } = 
     useBackend(
       // Stryker disable next-line all : don't test internal caching of React Query
       ["/api/commons/all"],
@@ -25,7 +24,7 @@ export default function HomePage() {
         url: "/api/commons/all"
       },
       []
-    ).data;
+    );
 
   const objectToAxiosParams = (newCommonsId) => ({
     url: "/api/commons/join",
@@ -48,14 +47,6 @@ export default function HomePage() {
         setCommonsJoined(currentUser.root.user.commons);
       }
     }, [currentUser]
-  );
-
-  useEffect(
-    () => {
-      if (commonsFromBackend) {
-        setCommons(commonsFromBackend);
-      }
-    }, [commonsFromBackend]
   );
 
   let navigate = useNavigate();

--- a/frontend/src/main/pages/LoginPage.js
+++ b/frontend/src/main/pages/LoginPage.js
@@ -14,16 +14,14 @@ const LoginCard = () => {
             <Card.Text>
             In order to start playing, please login.
             </Card.Text>
-            <Button href="/oauth2/authorization/google" variant="primary">Login</Button>
+            <Button href="/oauth2/authorization/google" variant="primary">Log In</Button>
         </Card.Body>
         </Card>
     )
 }
 
 export default function LoginPage() {
-    var [commons, setCommons] = useState([]);
-
-    const commonsFromBackend =
+    const { data: commons, error: commonError, status: commonStatus } = 
     useBackend(
       // Stryker disable next-line all : don't test internal caching of React Query
       ["/api/commons/all"],
@@ -32,19 +30,12 @@ export default function LoginPage() {
         url: "/api/commons/all"
       },
       []
-    ).data;
-
-    useEffect(
-        () => {
-          if (commonsFromBackend) {
-            setCommons(commonsFromBackend);
-          }
-        }, [commonsFromBackend]
     );
 
+    var listCommons = commons;
     if(commons.length > 5){
-        commons = commons.slice(0, 5);
-        commons.push({id: "...", name: "..."});
+        listCommons = commons.slice(0, 5);
+        listCommons.push({id: "...", name: "..."});
     }
 
     return (
@@ -57,7 +48,7 @@ export default function LoginPage() {
                 }
               <Row style={{ alignItems: "center", justifyContent: "center"}}>
                 <Col sm="auto"><LoginCard/></Col>
-                <Col sm="5"><CommonsList title="Available Commons" commonList={ commons } buttonText={null} buttonLink={null} /></Col>
+                <Col sm="5"><CommonsList title="Available Commons" commonList={ listCommons } buttonText={null} buttonLink={null} /></Col>
               </Row>
             </Container>
           </BasicLayout>

--- a/frontend/src/main/pages/LoginPage.js
+++ b/frontend/src/main/pages/LoginPage.js
@@ -21,7 +21,7 @@ const LoginCard = () => {
 }
 
 export default function LoginPage() {
-    const { data: commons, error: commonError, status: commonStatus } = 
+    const { data: commons, error: commonsError, status: commonsStatus } = 
     useBackend(
       // Stryker disable next-line all : don't test internal caching of React Query
       ["/api/commons/all"],
@@ -41,11 +41,7 @@ export default function LoginPage() {
     return (
         <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
           <BasicLayout>
-            {//<h1 data-testid="loginPage-title" style={{ fontSize: "40px", borderRadius: "7px", backgroundColor: "white", opacity: ".9" }} className="text-center border-0 my-3">Welcome to Happier Cows!</h1>
-            }
             <Container style={{ marginTop: "8%" }}>
-                {//We need these overrides, stylistic stuff.
-                }
               <Row style={{ alignItems: "center", justifyContent: "center"}}>
                 <Col sm="auto"><LoginCard/></Col>
                 <Col sm="5"><CommonsList title="Available Commons" commonList={ listCommons } buttonText={null} buttonLink={null} /></Col>

--- a/frontend/src/main/pages/LoginPage.js
+++ b/frontend/src/main/pages/LoginPage.js
@@ -1,0 +1,66 @@
+import React, { useState, useEffect } from "react"
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import CommonsList from "main/components/Commons/CommonsList";
+import { Container, Row, Col, Card, Button } from "react-bootstrap";
+import Background from './../../assets/HomePageBackground.jpg';
+
+import { useBackend } from "main/utils/useBackend";
+
+const LoginCard = () => {
+    return(
+        <Card style={{ width: '18rem' }}>
+        <Card.Body>
+            <Card.Title data-testid="loginPage-cardTitle">Welcome to Happier Cows!</Card.Title>
+            <Card.Text>
+            In order to start playing, please login.
+            </Card.Text>
+            <Button href="/oauth2/authorization/google" variant="primary">Login</Button>
+        </Card.Body>
+        </Card>
+    )
+}
+
+export default function LoginPage() {
+    var [commons, setCommons] = useState([]);
+    
+    const commonsFromBackend =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/commons/all"],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: "/api/commons/all"
+      },
+      []
+    ).data;
+
+    useEffect(
+        () => {
+          if (commonsFromBackend) {
+            setCommons(commonsFromBackend);
+          }
+        }, [commonsFromBackend]
+    );
+    
+    if(commons.length > 5){
+        commons = commons.slice(0, 5);
+        commons.push({id: "...", name: "..."});
+    }
+
+    return (
+        <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
+          <BasicLayout>
+            {//<h1 data-testid="loginPage-title" style={{ fontSize: "40px", borderRadius: "7px", backgroundColor: "white", opacity: ".9" }} className="text-center border-0 my-3">Welcome to Happier Cows!</h1>
+            }
+            <Container style={{ marginTop: "8%" }}>
+                {//We need these overrides, stylistic stuff.
+                }
+              <Row style={{ alignItems: "center", justifyContent: "center"}}>
+                <Col sm="auto"><LoginCard/></Col>
+                <Col sm="5"><CommonsList data-testid="loginPage-commonsList" title="Available Commons" commonList={ commons } buttonText={null} buttonLink={null} /></Col>
+              </Row>
+            </Container>
+          </BasicLayout>
+        </div>
+    )
+}

--- a/frontend/src/main/pages/LoginPage.js
+++ b/frontend/src/main/pages/LoginPage.js
@@ -22,7 +22,7 @@ const LoginCard = () => {
 
 export default function LoginPage() {
     var [commons, setCommons] = useState([]);
-    
+
     const commonsFromBackend =
     useBackend(
       // Stryker disable next-line all : don't test internal caching of React Query
@@ -41,7 +41,7 @@ export default function LoginPage() {
           }
         }, [commonsFromBackend]
     );
-    
+
     if(commons.length > 5){
         commons = commons.slice(0, 5);
         commons.push({id: "...", name: "..."});
@@ -57,7 +57,7 @@ export default function LoginPage() {
                 }
               <Row style={{ alignItems: "center", justifyContent: "center"}}>
                 <Col sm="auto"><LoginCard/></Col>
-                <Col sm="5"><CommonsList data-testid="loginPage-commonsList" title="Available Commons" commonList={ commons } buttonText={null} buttonLink={null} /></Col>
+                <Col sm="5"><CommonsList title="Available Commons" commonList={ commons } buttonText={null} buttonLink={null} /></Col>
               </Row>
             </Container>
           </BasicLayout>

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -33,11 +33,7 @@ export function useBackend(queryKey, axiosParameters, initialData) {
         } catch (e) {
             const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
 
-            // jacksoncooper, TODO: This function cannot be ejecting toasts to the user, because it
-            // has an `initialData` parameter to handle failure. The user does not care about HTTP
-            // failures.
-
-            // toast(errorMessage);
+            toast(errorMessage);
 
             console.error(errorMessage, e);
             throw e;
@@ -64,7 +60,6 @@ const wrappedParams = async (params) => {
 
 export function useBackendMutation(objectToAxiosParams, useMutationParams, queryKey = null) {
     const queryClient = useQueryClient();
-
     return useMutation((object) => wrappedParams(objectToAxiosParams(object)), {
         onError: (data) => {
             toast(`${data}`)

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -7,7 +7,7 @@ import { toast } from "react-toastify";
 //  queryKey ["/api/users","4"]  for "/api/users?id=4"
 
 // For axiosParameters
-//   
+//
 // {
 //     method: 'post',
 //     url: '/user/12345',
@@ -16,7 +16,7 @@ import { toast } from "react-toastify";
 //       lastName: 'Flintstone'
 //     }
 //  }
-// 
+//
 
 // GET Example:
 // useBackend(
@@ -26,14 +26,19 @@ import { toast } from "react-toastify";
 // );
 
 export function useBackend(queryKey, axiosParameters, initialData) {
-
     return useQuery(queryKey, async () => {
         try {
             const response = await axios(axiosParameters);
             return response.data;
         } catch (e) {
             const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
-            toast(errorMessage);
+
+            // jacksoncooper, TODO: This function cannot be ejecting toasts to the user, because it
+            // has an `initialData` parameter to handle failure. The user does not care about HTTP
+            // failures.
+
+            // toast(errorMessage);
+
             console.error(errorMessage, e);
             throw e;
         }

--- a/frontend/src/stories/pages/LoginPage.stories.js
+++ b/frontend/src/stories/pages/LoginPage.stories.js
@@ -1,0 +1,17 @@
+
+import React from 'react';
+
+import LoginPage from "main/pages/LoginPage";
+
+export default {
+    title: 'pages/LoginPage',
+    component: LoginPage
+};
+
+const Template = () => <LoginPage />;
+
+export const Default = Template.bind({});
+
+
+
+

--- a/frontend/src/tests/components/Commons/CommonsList.test.js
+++ b/frontend/src/tests/components/Commons/CommonsList.test.js
@@ -6,7 +6,7 @@ describe("CommonsList tests", () => {
 
     test("renders without crashing when button text is set", () => {
         const { getByTestId, getAllByTestId } = render(
-            <CommonsList commonList = {commonsFixtures.threeCommons} buttonText = {"Join"} />
+            <CommonsList commonList = {commonsFixtures.threeCommons} buttonText = {"Join"} title="Join A Commons"/>
         );
 
         const title = getByTestId("commonsList-title");
@@ -58,7 +58,7 @@ describe("CommonsList tests", () => {
         const title = getByTestId("commonsList-title");
         expect(title).toBeInTheDocument();
         expect(typeof(title.textContent)).toBe('string');
-        expect(title.textContent).toEqual(' A Commons');
+        expect(title.textContent).toEqual('');
 
         const subtitle_name = getByTestId("commonsList-subtitle-name");
         expect(subtitle_name).toBeInTheDocument();

--- a/frontend/src/tests/pages/LoginPage.test.js
+++ b/frontend/src/tests/pages/LoginPage.test.js
@@ -1,0 +1,56 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import LoginPage from "main/pages/LoginPage";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import commonsFixtures from "fixtures/commonsFixtures";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+describe("LoginPage tests", () => {
+    const queryClient = new QueryClient();
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    });
+
+    test("renders without crashing when lists return empty list", () => {
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/commons/all").reply(200, []);
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <LoginPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        const title = getByTestId("loginPage-cardTitle");
+        expect(title).toBeInTheDocument();
+        expect(typeof (title.textContent)).toBe('string');
+        expect(title.textContent).toEqual('Welcome to Happier Cows!');
+    });
+
+    /** 
+    test("renders only a max of 6 elements in the list, despite there being 7 commons.", () => {
+        apiCurrentUserFixtures.userOnly.user.commons = commonsFixtures.sevenCommons;
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.sevenCommons);
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <LoginPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        const commonsList = getByTestId("loginPage-commonsList");
+        expect(commonsList.commons.length).toEqual(6);
+    });
+    **/
+});

--- a/frontend/src/tests/pages/LoginPage.test.js
+++ b/frontend/src/tests/pages/LoginPage.test.js
@@ -8,6 +8,7 @@ import commonsFixtures from "fixtures/commonsFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { getAllByTestId } from "@testing-library/dom";
 
 describe("LoginPage tests", () => {
     const queryClient = new QueryClient();
@@ -36,12 +37,11 @@ describe("LoginPage tests", () => {
         expect(title.textContent).toEqual('Welcome to Happier Cows!');
     });
 
-    /** 
-    test("renders only a max of 6 elements in the list, despite there being 7 commons.", () => {
+    test("renders only a max of 6 elements in the list, despite there being 7 commons.", async () => {
         apiCurrentUserFixtures.userOnly.user.commons = commonsFixtures.sevenCommons;
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.sevenCommons);
-        const { getByTestId } = render(
+        const { findAllByTestId, getAllByTestId } = render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <LoginPage />
@@ -49,8 +49,10 @@ describe("LoginPage tests", () => {
             </QueryClientProvider>
         );
 
-        const commonsList = getByTestId("loginPage-commonsList");
-        expect(commonsList.commons.length).toEqual(6);
+        await findAllByTestId("commonsCard-id");
+
+        const cards = getAllByTestId("commonsCard-name");
+
+        expect(cards.length).toEqual(6);
     });
-    **/
 });

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -46,7 +46,7 @@ public class CommonsController extends ApiController {
   ObjectMapper mapper;
 
   @ApiOperation(value = "Get a list of all commons")
-  @PreAuthorize("hasRole('ROLE_USER')")
+  //@PreAuthorize("hasRole('ROLE_USER')")
   @GetMapping("/all")
   public ResponseEntity<String> getCommons() throws JsonProcessingException {
     log.info("getCommons()...");

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -48,7 +48,6 @@ public class CommonsController extends ApiController {
   ObjectMapper mapper;
 
   @ApiOperation(value = "Get a list of all commons")
-  //@PreAuthorize("hasRole('ROLE_USER')")
   @GetMapping("/all")
   public ResponseEntity<String> getCommons() throws JsonProcessingException {
     log.info("getCommons()...");


### PR DESCRIPTION
So we were able to silence the toasts, not by changing them. But by adding an entire layer to prevent them from seeing content while not-logged in. Which is completely unnecessary - i'll admit. But it works perfectly.

New Files:
-LoginPage.js (features a login card and public preview list of commons)
-LoginPage.test.js  (full coverage thanks to Jackson)
-LoginPage.stories.js (storybook entry)

Includes changes to:
-App.js (routes to support login/non-logged in users
-CommonsList (we hardcoded the title, this time added a specification variable -> props.title, which can be passed through.
-CommonsList.test.js (changed the hardcoded title, so I modified the tests for it.)
-commonsFixtures.js (new fixture with 7 commons to test the new public list)
-CommonsController's GET all commons call has been changed to allow anyone to call it, since we need it for the public list.

-HomePage.js and LoginPage.js use a different type of request now. I removed the seemingly useless useEffect() w/ commonsFromBackend, making them now directly pull into {data : commons} from useBackend(). This simplifies some of the code and also brings our npm coverage to 100%.

I want to be reasonable with this PR. If at any point the staff feels that we should forego the public list, which would revert most of the changes (except to App.js), I am fine with keeping just the loginPage w/ a loginCard.



