### PR TITLE
jc - Patch form that creates commons to supply `startingDate` to POST.

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import ProfilePage from "main/pages/ProfilePage";
 
 import AdminUsersPage from "main/pages/AdminUsersPage";
 import AdminCreateCommonsPage from "main/pages/AdminCreateCommonsPage";
+import AdminListCommonsPage from "main/pages/AdminListCommonPage";
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import PlayPage from "main/pages/PlayPage"; 
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -23,6 +23,9 @@ function App() {
           {
             hasRole(currentUser, "ROLE_ADMIN") && <Route path="/admin/createcommons" element={<AdminCreateCommonsPage />} />
           }
+          {
+            hasRole(currentUser, "ROLE_ADMIN") && <Route path="/admin/listcommons" element={<AdminListCommonsPage />} />
+          }
           <Route path="/play/:commonsId" element={<PlayPage />} /> 
         </Routes>
       </BrowserRouter>

--- a/frontend/src/fixtures/commonsFixtures.js
+++ b/frontend/src/fixtures/commonsFixtures.js
@@ -4,25 +4,32 @@ const commonsFixtures = {
             "id": 5,
             "name": "Seths Common",
             "day": 5,
-            "endDate": "6/11/2021",
+            "startDate": "20131219",
+            "endDate": "20141212",
             "totalPlayers": 50,
             "cowPrice": 15,
+            "milkPrice": 10,
         },
         {
             "id": 4,
             "name": "Kevin's Commons",
             "day": 5,
-            "endDate": "6/11/2021",
+            "startDate": "20181219",
+            "endDate": "20191212",
             "totalPlayers": 50,
             "cowPrice": 15,
+            "milkPrice": 10,
         },
         {
             "id": 1,
             "name": "Anika's Commons",
             "day": 5,
+            "startDate": "20151219",
+            "endDate": "20161212",
             "endDate": "6/11/2021",
             "totalPlayers": 50,
             "cowPrice": 15,
+            "milkPrice": 10,
         }
     ],
     oneCommons:
@@ -31,9 +38,11 @@ const commonsFixtures = {
                 "id": 1,
                 "name": "Anika's Commons",
                 "day": 5,
-                "endDate": "6/11/2021",
+                "startDate": "20171219",
+                "endDate": "20181212",
                 "totalPlayers": 50,
                 "cowPrice": 15,
+                "milkPrice": 10,
             }
         ]
 }

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -34,33 +34,30 @@ export default function CommonsTable({ commons, currentUser }) {
             
         },
         {
-            Header:'name',
+            Header:'Name',
             accessor: 'name',
         },
         {
-            Header:'day',
-            accesor:'day',
+            Header:'Cow Price',
+            accessor: row => String(row.cowPrice),
+            id: 'cowPrice'
+        }, 
+        {
+            Header:'Milk Price',
+            accessor: row => String(row.milkPrice),
+            id: 'milkPrice'
         },
         {
-            Header:'startDate',
-            accesor:'startDate',
+            Header:'Starting Balance',
+            accessor: row => String(row.startingBalance),
+            id: 'startingBalance'
         },
         {
-            Header:'endDate',
-            accesor:'endDate',
-        },
-        {
-            Header:'totalPlayers',
-            accesor:'totalPlayers',
-        },
-        {
-            Header:'cowPrice',
-            accesor:'cowPrice',
-        },
-        {
-            Header:'milkPrice',
-            accesor:'milkPrice',
-        },
+            Header:'Starting Date',
+            //accessor: row => row.startingDate.toString(),
+            accessor: row => String(row.startingDate),
+            id: 'startingDate'
+        }
     ];
 
     if (hasRole(currentUser, "ROLE_ADMIN")) {

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -21,7 +21,7 @@ export default function CommonsTable({ commons, currentUser }) {
         { onSuccess: onDeleteSuccess },
         ["/api/commons/all"]
     );
-    // Stryker enable all 
+    // Stryker enable all
 
     // Stryker disable next-line all : TODO try to make a good test for this
     const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
@@ -31,7 +31,7 @@ export default function CommonsTable({ commons, currentUser }) {
         {
             Header: 'id',
             accessor: 'id', // accessor is the "key" in the data
-            
+
         },
         {
             Header:'Name',
@@ -41,7 +41,7 @@ export default function CommonsTable({ commons, currentUser }) {
             Header:'Cow Price',
             accessor: row => String(row.cowPrice),
             id: 'cowPrice'
-        }, 
+        },
         {
             Header:'Milk Price',
             accessor: row => String(row.milkPrice),
@@ -63,11 +63,15 @@ export default function CommonsTable({ commons, currentUser }) {
     if (hasRole(currentUser, "ROLE_ADMIN")) {
         columns.push(ButtonColumn("Edit", "primary", editCallback, "CommonsTable"));
         columns.push(ButtonColumn("Delete", "danger", deleteCallback, "CommonsTable"));
-    } 
+    }
 
     // Stryker disable next-line ArrayDeclaration : [columns] is a performance optimization
     const memoizedColumns = React.useMemo(() => columns, [columns]);
     const memoizedCommons = React.useMemo(() => commons, [commons]);
+
+    for (let readable of commons) {
+        readable.startingDate = new Date(readable.startingDate).toLocaleString();
+    }
 
     return <OurTable
         data={memoizedCommons}

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -1,0 +1,51 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+// import { toast } from "react-toastify";
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/commonsUtils"
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function CommonsTable({ commons, currentUser }) {
+
+    const navigate = useNavigate();
+
+    const editCallback = (cell) => {
+        navigate(`/commons/edit/${cell.row.values.id}`)
+    }
+
+    // Stryker disable all : hard to test for query caching
+
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/commons/all"]
+    );
+    // Stryker enable all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+
+    const columns = [
+        {
+            Header: 'Commons',
+            accessor: 'commons', // accessor is the "key" in the data
+        }
+    ];
+
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        columns.push(ButtonColumn("Edit", "primary", editCallback, "CommonsTable"));
+        columns.push(ButtonColumn("Delete", "danger", deleteCallback, "CommonsTable"));
+    } 
+
+    // Stryker disable next-line ArrayDeclaration : [columns] is a performance optimization
+    const memoizedColumns = React.useMemo(() => columns, [columns]);
+    const memoizedCommons = React.useMemo(() => commons, [commons]);
+
+    return <OurTable
+        data={memoizedCommons}
+        columns={memoizedColumns}
+        testid={"CommonsTable"}
+    />;
+};

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -29,9 +29,38 @@ export default function CommonsTable({ commons, currentUser }) {
 
     const columns = [
         {
-            Header: 'Commons',
-            accessor: 'commons', // accessor is the "key" in the data
-        }
+            Header: 'id',
+            accessor: 'id', // accessor is the "key" in the data
+            
+        },
+        {
+            Header:'name',
+            accessor: 'name',
+        },
+        {
+            Header:'day',
+            accesor:'day',
+        },
+        {
+            Header:'startDate',
+            accesor:'startDate',
+        },
+        {
+            Header:'endDate',
+            accesor:'endDate',
+        },
+        {
+            Header:'totalPlayers',
+            accesor:'totalPlayers',
+        },
+        {
+            Header:'cowPrice',
+            accesor:'cowPrice',
+        },
+        {
+            Header:'milkPrice',
+            accesor:'milkPrice',
+        },
     ];
 
     if (hasRole(currentUser, "ROLE_ADMIN")) {

--- a/frontend/src/main/components/Commons/CreateCommonsForm.js
+++ b/frontend/src/main/components/Commons/CreateCommonsForm.js
@@ -23,7 +23,6 @@ export default function CreateCommonsForm(props) {
           {errors.name?.message}
         </Form.Control.Feedback>
       </Form.Group>
-      
 
       <Form.Group className="mb-3">
         <Form.Label htmlFor="startingBalance">Starting Balance</Form.Label>
@@ -80,12 +79,12 @@ export default function CreateCommonsForm(props) {
       </Form.Group>
 
       <Form.Group className="mb-3">
-        <Form.Label htmlFor="startDate">Start Date</Form.Label>
+        <Form.Label htmlFor="startingDate">Start Date</Form.Label>
         <Form.Control
-          id="startDate"
+          id="startingDate"
           type="date"
-          isInvalid={!!errors.startDate}
-          {...register("startDate", {
+          isInvalid={!!errors.startingDate}
+          {...register("startingDate", {
             valueAsDate: true,
             validate: {
               isPresent: (v) => !isNaN(v) || "Start date is required",

--- a/frontend/src/main/components/Commons/CreateCommonsForm.js
+++ b/frontend/src/main/components/Commons/CreateCommonsForm.js
@@ -23,6 +23,7 @@ export default function CreateCommonsForm(props) {
           {errors.name?.message}
         </Form.Control.Feedback>
       </Form.Group>
+      
 
       <Form.Group className="mb-3">
         <Form.Label htmlFor="startingBalance">Starting Balance</Form.Label>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -48,6 +48,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                   <NavDropdown title="Admin" id="appnavbar-admin-dropdown" data-testid="appnavbar-admin-dropdown" >
                     <NavDropdown.Item href="/admin/createcommons">Create Commons</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
+                    <NavDropdown.Item href="admin/listcommons">List Commons</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -48,7 +48,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                   <NavDropdown title="Admin" id="appnavbar-admin-dropdown" data-testid="appnavbar-admin-dropdown" >
                     <NavDropdown.Item href="/admin/createcommons">Create Commons</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
-                    <NavDropdown.Item href="admin/listcommons">List Commons</NavDropdown.Item>
+                    <NavDropdown.Item href="/admin/listcommons">List Commons</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -57,3 +57,20 @@ export default function OurTable({ columns, data, testid="testid"}) {
     </Table>
   )
 }
+
+export function ButtonColumn(label, variant, callback, testid) {
+  const column = {
+    Header: label,
+    id: label,
+    Cell: ({ cell }) => (
+      <Button
+        variant={variant}
+        onClick={() => callback(cell)}
+        data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
+      >
+        {label}
+      </Button>
+    )
+  }
+  return column;
+}

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { useTable, useSortBy } from 'react-table'
-import { Table } from "react-bootstrap";
-
+import { Table, Button } from "react-bootstrap";
 export default function OurTable({ columns, data, testid="testid"}) {
 
   const {

--- a/frontend/src/main/pages/AdminListCommonPage.js
+++ b/frontend/src/main/pages/AdminListCommonPage.js
@@ -2,24 +2,26 @@ import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import CommonsTable from 'main/components/Commons/CommonsTable';
 import { useBackend } from 'main/utils/useBackend';
-import { useCurrentUser } from 'main/utils/currentUser'
-
+//import { useCurrentUser } from 'main/utils/currentUser'
+import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 
 export default function AdminListCommonsPage () {
 
 const currentUser = useCurrentUser();
 
-  const { data: commons, error: _error, status: _status } =
-    useBackend(
-      // Stryker disable next-line all : don't test internal caching of React Query
-      ["/api/commons/all"],
-      { method: "GET", url: "/api/commons/all" },
-      []
-    );
-
-
+    const { data: commons, error: _error, status: _status } =
+      
+      useBackend(
+        // Stryker disable next-line all : don't test internal caching of React Query
+        ["/api/commons/all"],
+        { method: "GET", url: "/api/commons/all" },
+        []
+      );
+      
     
+
+    //console.log(commons)
 
     return (
         <BasicLayout>
@@ -29,5 +31,8 @@ const currentUser = useCurrentUser();
           </div>
         </BasicLayout>
       )
+    
+
+    
 };
 

--- a/frontend/src/main/pages/AdminListCommonPage.js
+++ b/frontend/src/main/pages/AdminListCommonPage.js
@@ -1,0 +1,37 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import CommonsTable from 'main/components/Commons/CommonsTable';
+import { useBackend } from 'main/utils/useBackend';
+import { useCurrentUser } from 'main/utils/currentUser'
+import { useBackendMutation } from "main/utils/useBackend";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+const AdminListCommonsPage = () => {
+
+const currentUser = useCurrentUser();
+
+  const { data: commons, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/commons/all"],
+      { method: "GET", url: "/api/commons/all" },
+      []
+    );
+
+
+    
+
+    return (
+        <BasicLayout>
+          <div className="pt-2">
+            <h1>List Commons</h1>
+            <CommonsTable commons={commons} currentUser={currentUser} />
+          </div>
+        </BasicLayout>
+      )
+};
+
+export default AdminListCommonsPage;

--- a/frontend/src/main/pages/AdminListCommonPage.js
+++ b/frontend/src/main/pages/AdminListCommonPage.js
@@ -3,13 +3,10 @@ import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import CommonsTable from 'main/components/Commons/CommonsTable';
 import { useBackend } from 'main/utils/useBackend';
 import { useCurrentUser } from 'main/utils/currentUser'
-import { useBackendMutation } from "main/utils/useBackend";
-
-import axios from "axios";
-import AxiosMockAdapter from "axios-mock-adapter";
 
 
-const AdminListCommonsPage = () => {
+
+export default function AdminListCommonsPage () {
 
 const currentUser = useCurrentUser();
 
@@ -34,4 +31,3 @@ const currentUser = useCurrentUser();
       )
 };
 
-export default AdminListCommonsPage;

--- a/frontend/src/main/utils/commonsUtils.js
+++ b/frontend/src/main/utils/commonsUtils.js
@@ -1,0 +1,17 @@
+import { toast } from "react-toastify";
+import { useNavigate } from 'react-router-dom'
+
+export function onDeleteSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/commons",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}

--- a/frontend/src/stories/pages/AdminListCommonPage.stories.js
+++ b/frontend/src/stories/pages/AdminListCommonPage.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import AdminListCommonPage from "main/pages/commons/AdminListCommonPage";
+import AdminListCommonPage from "main/pages/AdminListCommonPage";
 
 export default {
     title: 'pages/AdminListCommonPage',

--- a/frontend/src/stories/pages/AdminListCommonPage.stories.js
+++ b/frontend/src/stories/pages/AdminListCommonPage.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import AdminListCommonPage from "main/pages/commons/AdminListCommonPage";
+
+export default {
+    title: 'pages/AdminListCommonPage',
+    component: AdminListCommonPage
+};
+
+const Template = () => <AdminListCommonPage />;
+
+export const Default = Template.bind({});

--- a/frontend/src/tests/components/OurTable.test.js
+++ b/frontend/src/tests/components/OurTable.test.js
@@ -1,5 +1,6 @@
 import { render, waitFor, fireEvent } from "@testing-library/react";
-import OurTable from "main/components/OurTable";
+//import OurTable from "main/components/OurTable";
+import OurTable, {ButtonColumn} from "main/components/OurTable";
 
 describe("OurTable tests", () => {
     const threeRows = [
@@ -16,6 +17,7 @@ describe("OurTable tests", () => {
             col2: 'you want',
         }
     ];
+    const clickMeCallback = jest.fn();
 
     const columns = [
         {
@@ -25,7 +27,8 @@ describe("OurTable tests", () => {
         {
             Header: 'Column 2',
             accessor: 'col2',
-        }
+        },
+        ButtonColumn("Click", "primary", clickMeCallback, "testId"),
     ];
 
     test("renders an empty table without crashing", () => {

--- a/frontend/src/tests/components/OurTable.test.js
+++ b/frontend/src/tests/components/OurTable.test.js
@@ -43,6 +43,17 @@ describe("OurTable tests", () => {
         );
     });
 
+    test("The button appears in the table", async () => {
+        const {getByTestId} = render(
+            <OurTable columns={columns} data={threeRows} />
+        );
+
+        await waitFor(()=> expect(getByTestId("testId-cell-row-0-col-Click-button")).toBeInTheDocument() );
+        const button = getByTestId("testId-cell-row-0-col-Click-button");
+        fireEvent.click(button);
+        await waitFor(()=>expect(clickMeCallback).toBeCalledTimes(1));
+    });
+
     test("default testid is testId", async () => {
         const {getByTestId } = render(
             <OurTable columns={columns} data={threeRows} />

--- a/frontend/src/tests/pages/AdminListCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminListCommonsPage.test.js
@@ -89,9 +89,10 @@ describe("AdminListCommonPage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("5"); });
-        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("4");
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
         expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+        
 
     });
 

--- a/frontend/src/tests/pages/AdminListCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminListCommonsPage.test.js
@@ -1,0 +1,125 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import AdminListCommonPage from "main/pages/AdminListCommonPage";
+
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import commonsFixtures from "fixtures/commonsFixtures"; 
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("AdminListCommonPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+
+    const testId = "CommonsTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/commons/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminListCommonPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/commons/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminListCommonPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+
+
+    test("renders three commons without crashing for admin user", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.threeCommons);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminListCommonPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("5"); });
+        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("4");
+        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+    });
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        setupUserOnly();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/commons/all").timeout();
+
+        const restoreConsole = mockConsole();
+
+        const { queryByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminListCommonPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/commons/all");
+        restoreConsole();
+
+        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+ 
+
+});

--- a/frontend/src/tests/pages/AdminListCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminListCommonsPage.test.js
@@ -89,9 +89,9 @@ describe("AdminListCommonPage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
-        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("5"); });
+        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("4");
+        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("1");
         
 
     });


### PR DESCRIPTION
The `Commons` type was expanded in #30 to include a `startingDate` member. The form dumps its elements into the body of a POST request to `/api/commons/new`, so we need to make sure the elements have the correct `id` (?) property. I'm struggling to figure out the internals of `react-hook-form`, and which values it uses for the POST.

Forked from @Jacqueskim's branch that implements the page that lists commons for ease of testing. So we should merge #40 first.

Addresses #36.