### PR TITLE
W22-6pm-3 Success toast shows correct information when creating a new commons

### DIFF
--- a/frontend/src/main/pages/AdminCreateCommonsPage.js
+++ b/frontend/src/main/pages/AdminCreateCommonsPage.js
@@ -19,7 +19,7 @@ const AdminCreateCommonsPage = () => {
     });
 
     const onSuccess = (commons) => {
-        toast(`Commons successfully created! - id: ${commons.id} name: ${commons.name} startDate${commons.startDate} cowPrice ${commons.milkPrice}`);
+        toast(`Commons successfully created! - id: ${commons.id} name: ${commons.name} startDate${commons.startingDate} cowPrice ${commons.milkPrice}`);
         console.log(commons.milkPrice);
     }
    

--- a/frontend/src/main/pages/AdminCreateCommonsPage.js
+++ b/frontend/src/main/pages/AdminCreateCommonsPage.js
@@ -19,7 +19,7 @@ const AdminCreateCommonsPage = () => {
     });
 
     const onSuccess = (commons) => {
-        toast(`Commons successfully created! - id: ${commons.id} name: ${commons.name} startDate${commons.startingDate} cowPrice ${commons.milkPrice}`);
+        toast(`Commons successfully created! - id: ${commons.id} name: ${commons.name} startDate: ${commons.startingDate} cowPrice ${commons.milkPrice}`);
         console.log(commons.milkPrice);
     }
    


### PR DESCRIPTION

# Overview

Modified the create commons toast on the AdminCreateCommonsPage to retrieve the correct variable "startingDate" from commons. Also reformatted the toast to include a semicolon and space so that the message is more legible. 

Before: 
<img width="408" alt="Screen Shot 2022-03-12 at 1 32 44 PM" src="https://user-images.githubusercontent.com/62913184/158035782-8a7eeb19-a33e-4085-b5e3-f117faa01433.png">

After
![Image from iOS](https://user-images.githubusercontent.com/62913184/158035792-05c0b13d-4ca5-4cd8-963f-89164677d041.jpg)



# Issues Addressed

#55 solved
