### PR TITLE
6pm-3: Buy and Sell working through Swagger/Backend

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
@@ -83,15 +83,12 @@ public class ProfitsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/all/commons")
     public Iterable<Profit> allProfitsByUserCommonsId(
-            @ApiParam("userCommonsId") @RequestParam Long userCommonsId) {
+            @ApiParam("commonsId") @RequestParam Long commonsId) {
         Long userId = getCurrentUser().getUser().getId();
 
-        UserCommons userCommons = userCommonsRepository.findById(userCommonsId).orElseThrow(() -> new EntityNotFoundException(UserCommons.class, userCommonsId));
+        UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId).orElseThrow(() -> new EntityNotFoundException(UserCommons.class, "commonsId", commonsId, "userId", userId));
 
-        if (userId != userCommons.getUserId())
-            throw new EntityNotFoundException(UserCommons.class, userCommonsId);
-
-        Iterable<Profit> profits = profitRepository.findAllByUserCommonsId(userCommonsId);
+        Iterable<Profit> profits = profitRepository.findAllByUserCommonsId(userCommons.getId());
 
         return profits;
     }

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -12,12 +12,21 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+
+import org.springframework.http.ResponseEntity;
+import javax.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Api(description = "User Commons")
 @RequestMapping("/api/usercommons")
@@ -26,6 +35,9 @@ public class UserCommonsController extends ApiController {
 
   @Autowired
   private UserCommonsRepository userCommonsRepository;
+
+  @Autowired
+  private CommonsRepository commonsRepository;
 
   @Autowired
   ObjectMapper mapper;
@@ -56,5 +68,64 @@ public class UserCommonsController extends ApiController {
             () -> new EntityNotFoundException(UserCommons.class, "commonsId", commonsId, "userId", userId));
     return userCommons;
   }
+
+  @ApiOperation(value = "Buy a cow, totalWealth updated")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @PutMapping("/buy")
+  public ResponseEntity<String> putUserCommonsByIdBuy(
+          @ApiParam("commonsId") @RequestParam Long commonsId, 
+            @RequestBody @Valid UserCommons incomingUserCommons) throws JsonProcessingException {
+        User u = getCurrentUser().getUser();
+        Long userId = u.getId();
+
+        Commons commons = commonsRepository.findById(commonsId).orElseThrow( 
+          ()->new EntityNotFoundException(Commons.class, commonsId));
+        UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)
+        .orElseThrow(
+            () -> new EntityNotFoundException(UserCommons.class, "commonsId", commonsId, "userId", userId));
+
+
+        long previousId = userCommons.getId();
+        incomingUserCommons.setId(previousId);
+        if(incomingUserCommons.getTotalWealth() >= commons.getCowPrice() ){
+          incomingUserCommons.setTotalWealth(incomingUserCommons.getTotalWealth() - commons.getCowPrice());
+          incomingUserCommons.setNumOfCows(incomingUserCommons.getNumOfCows() + 1);
+        }
+        userCommonsRepository.save(incomingUserCommons);
+
+        String body = mapper.writeValueAsString(incomingUserCommons);
+        return ResponseEntity.ok().body(body);
+    }
+
+
+
+  @ApiOperation(value = "Sell a cow, totalWealth updated")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @PutMapping("/sell")
+  public ResponseEntity<String> putUserCommonsByIdSell(
+          @ApiParam("commonsId") @RequestParam Long commonsId, 
+            @RequestBody @Valid UserCommons incomingUserCommons) throws JsonProcessingException {
+        User u = getCurrentUser().getUser();
+        Long userId = u.getId();
+
+        Commons commons = commonsRepository.findById(commonsId).orElseThrow( 
+          ()->new EntityNotFoundException(Commons.class, commonsId));
+        UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)
+        .orElseThrow(
+            () -> new EntityNotFoundException(UserCommons.class, "commonsId", commonsId, "userId", userId));
+
+
+        long previousId = userCommons.getId();
+        incomingUserCommons.setId(previousId);
+        //TODO: Change this equation to be based on cowhealth
+        if(incomingUserCommons.getNumOfCows() >= 1 ){
+          incomingUserCommons.setTotalWealth(incomingUserCommons.getTotalWealth() + commons.getCowPrice());
+          incomingUserCommons.setNumOfCows(incomingUserCommons.getNumOfCows() - 1);
+        }
+        userCommonsRepository.save(incomingUserCommons);
+
+        String body = mapper.writeValueAsString(incomingUserCommons);
+        return ResponseEntity.ok().body(body);
+    }
 
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -15,7 +15,7 @@ import lombok.AccessLevel;
 
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @Entity(name = "commons")
 public class Commons

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
@@ -26,7 +26,7 @@ public class UserCommons {
   @Column(name="user_id")
   private long userId;  
 
-  private int totalWealth;
+  private double totalWealth;
 
   private int numOfCows;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -23,8 +23,8 @@ import edu.ucsb.cs156.happiercows.entities.User;
 public class CreateCommonsParams
 {
   private String name;
-  @NumberFormat private double cowPrice;
-  @NumberFormat private double milkPrice;
-  @NumberFormat private double startingBalance;
+  @NumberFormat private Double cowPrice;
+  @NumberFormat private Double milkPrice;
+  @NumberFormat private Double startingBalance;
   @DateTimeFormat private LocalDateTime startingDate;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/UserCommonsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/UserCommonsRepository.java
@@ -11,5 +11,4 @@ import edu.ucsb.cs156.happiercows.entities.UserCommons;
 public interface UserCommonsRepository extends CrudRepository<UserCommons, Long> {
     Optional<UserCommons> findByCommonsIdAndUserId(Long commonsId, Long userId );
 
-    void deleteAllByCommonsId(Long commonsId);
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -121,63 +121,6 @@ public class CommonsControllerTests extends ControllerTestCase {
     assertEquals(actualCommons, expectedCommons);
   }
 
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void updateCommonsTest() throws Exception
-  {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-      .name("Jackson's Commons")
-      .cowPrice(500.99)
-      .milkPrice(8.99)
-      .startingBalance(1020.10)
-      .startingDate(someTime)
-      .build();
-
-    Commons commons = Commons.builder()
-      .name("Jackson's Commons")
-      .cowPrice(500.99)
-      .milkPrice(8.99)
-      .startingBalance(1020.10)
-      .startingDate(someTime)
-      .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.save(commons))
-      .thenReturn(commons);
-
-    mockMvc
-      .perform(put("/api/commons/update?id=0").with(csrf())
-        .contentType(MediaType.APPLICATION_JSON)
-        .characterEncoding("utf-8")
-        .content(requestBody))
-      .andExpect(status().isCreated());
-
-    verify(commonsRepository, times(1)).save(commons);
-
-    parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
-    commons.setMilkPrice(parameters.getMilkPrice());
-
-    requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.findById(0L))
-      .thenReturn(Optional.of(commons));
-
-    when(commonsRepository.save(commons))
-      .thenReturn(commons);
-
-    mockMvc
-      .perform(put("/api/commons/update?id=0").with(csrf())
-        .contentType(MediaType.APPLICATION_JSON)
-        .characterEncoding("utf-8")
-        .content(requestBody))
-      .andExpect(status().isNoContent());
-
-    verify(commonsRepository, times(1)).save(commons);
-  }
-
   //This common SHOULD be in the repository
   @WithMockUser(roles = { "USER" })
   @Test
@@ -229,6 +172,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .userId(1L)
         .commonsId(2L)
         .totalWealth(0)
+        .numOfCows(1)
         .build();
 
     UserCommons ucSaved = UserCommons.builder()
@@ -352,7 +296,6 @@ public class CommonsControllerTests extends ControllerTestCase {
         .andExpect(status().is(404)).andReturn();
 
     verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
-    verify(userCommonsRepository, times(1)).save(uc);
 
     Map<String, Object> responseMap = responseToJson(response);
 
@@ -360,61 +303,9 @@ public class CommonsControllerTests extends ControllerTestCase {
     assertEquals(responseMap.get("type"), "EntityNotFoundException");
   }
 
-    @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void deleteCommons_test_admin_exists() throws Exception {
-      LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-      Commons c = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .build();
-      
-      when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
-      doNothing().when(commonsRepository).deleteById(2L);
-      
-      MvcResult response = mockMvc.perform(
-              delete("/api/commons?id=2")
-                      .with(csrf()))
-              .andExpect(status().is(200)).andReturn();
-      
-      verify(commonsRepository, times(1)).findById(2L);
-      verify(commonsRepository, times(1)).deleteById(2L);
-      
-      String responseString = response.getResponse().getContentAsString();
-      
-      String expectedString = "{\"message\":\"commons with id 2 deleted\"}"; 
 
-      assertEquals(expectedString, responseString);
-  }
 
   @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void deleteCommons_test_admin_nonexists() throws Exception {
-      
-      when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
-      
-      MvcResult response = mockMvc.perform(
-              delete("/api/commons?id=2")
-                      .with(csrf()))
-              .andExpect(status().is(404)).andReturn();
-      
-      verify(commonsRepository, times(1)).findById(2L);
-      
-
-      String responseString = response.getResponse().getContentAsString();
-      
-      String expectedString = "{\"message\":\"Commons with id 2 not found\",\"type\":\"EntityNotFoundException\"}";
-      
-      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
-      Map<String, Object> jsonResponse = responseToJson(response);
-      assertEquals(expectedJson, jsonResponse);
-  }
-  
-  
-  @WithMockUser(roles = {"ADMIN"})
   @Test
   public void deleteUserFromCommonsTest() throws Exception {
     UserCommons uc = UserCommons.builder()

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
@@ -186,9 +186,9 @@ public class ProfitsControllerTests extends ControllerTestCase {
 
     expectedProfits.add(p1);
     when(profitRepository.findAllByUserCommonsId(1L)).thenReturn(expectedProfits);
-    when(userCommonsRepository.findById(1L)).thenReturn(Optional.of(expectedUserCommons));
+    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(expectedUserCommons));
 
-    MvcResult response = mockMvc.perform(get("/api/profits/all/commons?userCommonsId=1")).andDo(print()).andExpect(status().isOk()).andReturn();
+    MvcResult response = mockMvc.perform(get("/api/profits/all/commons?commonsId=2")).andDo(print()).andExpect(status().isOk()).andReturn();
 
     verify(profitRepository, times(1)).findAllByUserCommonsId(1L);
 
@@ -199,33 +199,34 @@ public class ProfitsControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = { "USER" })
   @Test
-  public void get_profits_all_commons_other_user() throws Exception {
+  public void get_profits_all_commons_user_nonexistent() throws Exception {
     List<Profit> expectedProfits = new ArrayList<Profit>();
-    UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(2).build();
+    UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(5).build();
     Profit p1 = Profit.builder().id(42).profit(100).timestamp(12).userCommons(expectedUserCommons).build();
 
     when(profitRepository.findAllByUserCommonsId(1L)).thenReturn(expectedProfits);
-    when(userCommonsRepository.findById(1L)).thenReturn(Optional.of(expectedUserCommons));
+    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.empty());
 
-    MvcResult response = mockMvc.perform(get("/api/profits/all/commons?userCommonsId=1").contentType("application/json")).andExpect(status().isNotFound()).andReturn();
+    MvcResult response = mockMvc.perform(get("/api/profits/all/commons?commonsId=2").contentType("application/json")).andExpect(status().isNotFound()).andReturn();
 
-    verify(userCommonsRepository, times(1)).findById(1L);
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
 
     Map<String, Object> json = responseToJson(response);
     assertEquals("EntityNotFoundException", json.get("type"));
-    assertEquals("UserCommons with id 1 not found", json.get("message"));
+    assertEquals("UserCommons with commonsId 2 and userId 1 not found", json.get("message"));
   }
 
   @WithMockUser(roles = { "USER" })
   @Test
   public void get_profits_all_commons_nonexistent() throws Exception {
-    MvcResult response = mockMvc.perform(get("/api/profits/all/commons?userCommonsId=1").contentType("application/json")).andExpect(status().isNotFound()).andReturn();
 
-    verify(userCommonsRepository, times(1)).findById(1L);
+    MvcResult response = mockMvc.perform(get("/api/profits/all/commons?commonsId=1").contentType("application/json")).andExpect(status().isNotFound()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(1L, 1L);
 
     Map<String, Object> json = responseToJson(response);
     assertEquals("EntityNotFoundException", json.get("type"));
-    assertEquals("UserCommons with id 1 not found", json.get("message"));
+    assertEquals("UserCommons with commonsId 2 and userId 1 not found", json.get("message"));
   }
 
   @WithMockUser(roles = { "ADMIN" })

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
@@ -226,7 +226,7 @@ public class ProfitsControllerTests extends ControllerTestCase {
 
     Map<String, Object> json = responseToJson(response);
     assertEquals("EntityNotFoundException", json.get("type"));
-    assertEquals("UserCommons with commonsId 2 and userId 1 not found", json.get("message"));
+    assertEquals("UserCommons with commonsId 1 and userId 1 not found", json.get("message"));
   }
 
   @WithMockUser(roles = { "ADMIN" })

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -129,3 +129,515 @@ public class UserCommonsControllerTests extends ControllerTestCase {
     assertEquals(expectedJson, jsonResponse);
   }
 }
+
+ // PUT(edit) tests
+
+@WithMockUser(roles = { "USER" })
+@Test
+public void test_BuyCow_commons_exists() throws Exception {
+
+    // arrange
+
+    UserCommons origUserCommons = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(1)
+    .build();
+
+    Commons randomCommons = Commons
+    .builder()
+    .name("test commons")
+    .cowPrice(10)
+    .milkPrice(2)
+    .startingBalance(300)
+    .startingDate(LocalDateTime.now())
+    .build();
+
+    UserCommons userCommonsToSend = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(1)
+    .build();
+
+    UserCommons correctuserCommons = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300-randomCommons.getCowPrice())
+    .numOfCows(2)
+    .build();
+
+    String requestBody = mapper.writeValueAsString(userCommonsToSend);
+    String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+    when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+    when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(randomCommons));
+
+    // act
+    MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1")
+        .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+    // assert
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+    verify(userCommonsRepository, times(1)).save(correctuserCommons);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedReturn, responseString);
+}
+
+@WithMockUser(roles = { "USER" })
+@Test
+public void test_SellCow_commons_exists() throws Exception {
+
+    // arrange
+
+    UserCommons origUserCommons = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(1)
+    .build();
+
+    Commons randomCommons = Commons
+    .builder()
+    .name("test commons")
+    .cowPrice(10)
+    .milkPrice(2)
+    .startingBalance(300)
+    .startingDate(LocalDateTime.now())
+    .build();
+
+    UserCommons userCommonsToSend = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(1)
+    .build();
+
+    UserCommons correctuserCommons = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300+randomCommons.getCowPrice())
+    .numOfCows(0)
+    .build();
+
+    String requestBody = mapper.writeValueAsString(userCommonsToSend);
+    String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+    when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+    when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(randomCommons));
+
+    // act
+    MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=1")
+        .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+    // assert
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+    verify(userCommonsRepository, times(1)).save(correctuserCommons);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedReturn, responseString);
+}
+
+@WithMockUser(roles = { "USER" })
+@Test
+public void test_BuyCow_commons_for_user_DOES_NOT_exist() throws Exception {
+
+    // arrange
+
+    UserCommons origUserCommons = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(1)
+    .build();
+
+    Commons randomCommons = Commons
+    .builder()
+    .name("test commons")
+    .cowPrice(10)
+    .milkPrice(2)
+    .startingBalance(300)
+    .startingDate(LocalDateTime.now())
+    .build();
+
+    UserCommons userCommonsToSend = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(1)
+    .build();
+
+    UserCommons correctuserCommons = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300-randomCommons.getCowPrice())
+    .numOfCows(2)
+    .build();
+
+    String requestBody = mapper.writeValueAsString(userCommonsToSend);
+    String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+    when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+    when(commonsRepository.findById(eq(234L))).thenReturn(Optional.of(randomCommons));
+
+    // act
+    MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=234") 
+        .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().is(404)).andReturn();
+
+    // assert
+
+    String responseString = response.getResponse().getContentAsString();
+    String expectedString = "{\"message\":\"UserCommons with commonsId 234 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
+    Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+    Map<String, Object> jsonResponse = responseToJson(response);
+    assertEquals(expectedJson, jsonResponse);
+}
+
+@WithMockUser(roles = { "USER" })
+@Test
+public void test_SellCow_commons_for_usercommons_DOES_NOT_exist() throws Exception {
+
+    // arrange
+
+    UserCommons origUserCommons = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(1)
+    .build();
+
+    Commons randomCommons = Commons
+    .builder()
+    .id(234L)
+    .name("test commons")
+    .cowPrice(10)
+    .milkPrice(2)
+    .startingBalance(300)
+    .startingDate(LocalDateTime.now())
+    .build();
+
+    UserCommons userCommonsToSend = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(1)
+    .build();
+
+    UserCommons correctuserCommons = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300+randomCommons.getCowPrice())
+    .numOfCows(2)
+    .build();
+
+    String requestBody = mapper.writeValueAsString(userCommonsToSend);
+    String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+    when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+    when(commonsRepository.findById(eq(234L))).thenReturn(Optional.of(randomCommons));
+
+    // act
+    MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=234")
+        .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().is(404)).andReturn();
+
+    // assert
+    String responseString = response.getResponse().getContentAsString();
+    String expectedString = "{\"message\":\"UserCommons with commonsId 234 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
+    Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+    Map<String, Object> jsonResponse = responseToJson(response);
+    assertEquals(expectedJson, jsonResponse);
+}
+
+@WithMockUser(roles = { "USER" })
+@Test
+public void test_SellCow_commons_DOES_NOT_exist() throws Exception {
+
+    // arrange
+
+    UserCommons origUserCommons = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(1)
+    .build();
+
+    Commons randomCommons = Commons
+    .builder()
+    .name("test commons")
+    .cowPrice(10)
+    .milkPrice(2)
+    .startingBalance(300)
+    .startingDate(LocalDateTime.now())
+    .build();
+
+    UserCommons userCommonsToSend = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(1)
+    .build();
+
+    UserCommons correctuserCommons = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300+randomCommons.getCowPrice())
+    .numOfCows(2)
+    .build();
+
+    String requestBody = mapper.writeValueAsString(userCommonsToSend);
+    String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+    when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+    when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(randomCommons));
+
+    // act
+    MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=222")
+        .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().is(404)).andReturn();
+
+    // assert
+    String responseString = response.getResponse().getContentAsString();
+    String expectedString = "{\"message\":\"Commons with id 222 not found\",\"type\":\"EntityNotFoundException\"}";
+    Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+    Map<String, Object> jsonResponse = responseToJson(response);
+    assertEquals(expectedJson, jsonResponse);
+}
+
+@WithMockUser(roles = { "USER" })
+@Test
+public void test_BuyCow_commons_DOES_NOT_exist() throws Exception {
+
+    // arrange
+
+    UserCommons origUserCommons = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(1)
+    .build();
+
+    Commons randomCommons = Commons
+    .builder()
+    .name("test commons")
+    .cowPrice(10)
+    .milkPrice(2)
+    .startingBalance(300)
+    .startingDate(LocalDateTime.now())
+    .build();
+
+    UserCommons userCommonsToSend = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(1)
+    .build();
+
+    UserCommons correctuserCommons = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300+randomCommons.getCowPrice())
+    .numOfCows(2)
+    .build();
+
+    String requestBody = mapper.writeValueAsString(userCommonsToSend);
+    String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+    when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+    when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(randomCommons));
+
+    // act
+    MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=222")
+        .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().is(404)).andReturn();
+
+    // assert
+    String responseString = response.getResponse().getContentAsString();
+    String expectedString = "{\"message\":\"Commons with id 222 not found\",\"type\":\"EntityNotFoundException\"}";
+    Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+    Map<String, Object> jsonResponse = responseToJson(response);
+    assertEquals(expectedJson, jsonResponse);
+}
+
+@WithMockUser(roles = { "USER" })
+@Test
+public void test_BuyCow_commons_exists_not_enough_money() throws Exception {
+
+    // arrange
+
+    UserCommons origUserCommons = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(0)
+    .numOfCows(1)
+    .build();
+
+    Commons randomCommons = Commons
+    .builder()
+    .name("test commons")
+    .cowPrice(10)
+    .milkPrice(2)
+    .startingBalance(0)
+    .startingDate(LocalDateTime.now())
+    .build();
+
+    UserCommons userCommonsToSend = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(0)
+    .numOfCows(1)
+    .build();
+
+    UserCommons correctuserCommons = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(0)
+    .numOfCows(1)
+    .build();
+
+    String requestBody = mapper.writeValueAsString(userCommonsToSend);
+    String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+    when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+    when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(randomCommons));
+
+    // act
+    MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1")
+        .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+    // assert
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+    verify(userCommonsRepository, times(1)).save(correctuserCommons);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedReturn, responseString);
+}
+
+@WithMockUser(roles = { "USER" })
+@Test
+public void test_SellCow_commons_exists_no_cow_to_sell() throws Exception {
+
+    // arrange
+
+    UserCommons origUserCommons = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(0)
+    .build();
+
+    Commons randomCommons = Commons
+    .builder()
+    .name("test commons")
+    .cowPrice(10)
+    .milkPrice(2)
+    .startingBalance(300)
+    .startingDate(LocalDateTime.now())
+    .build();
+
+    UserCommons userCommonsToSend = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(0)
+    .build();
+
+    UserCommons correctuserCommons = UserCommons
+    .builder()
+    .id(1L)
+    .userId(1L)
+    .commonsId(1L)
+    .totalWealth(300)
+    .numOfCows(0)
+    .build();
+
+    String requestBody = mapper.writeValueAsString(userCommonsToSend);
+    String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+    when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+    when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(randomCommons));
+
+    // act
+    MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=1")
+        .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+    // assert
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+    verify(userCommonsRepository, times(1)).save(correctuserCommons);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedReturn, responseString);
+}


### PR DESCRIPTION
# Overview

This PR adds the functionality of buy and sell to the backend and can be used through Swagger. The proper equations for buy and sell (using the weighted scale when selling) are not implemented at the moment through this PR. (The backend tests for buy and sell are not implemented yet in this PR explaining the drop in codecov at the moment)

# Issues Addressed

#14 is partially addressed in this PR

# Details

<img width="1407" alt="Screen Shot 2022-03-13 at 1 57 26 PM" src="https://user-images.githubusercontent.com/59851451/158079381-37c86148-9303-49c7-bf26-817ec770e139.png">

<img width="1407" alt="Screen Shot 2022-03-13 at 1 57 45 PM" src="https://user-images.githubusercontent.com/59851451/158079397-b570f02b-d327-4973-a741-4f159aa418e8.png">
 
The above two images showcase the buy function

<img width="1407" alt="Screen Shot 2022-03-13 at 1 58 33 PM" src="https://user-images.githubusercontent.com/59851451/158079409-a6d2602f-5654-4016-8e95-6df9f52d8092.png">

<img width="1407" alt="Screen Shot 2022-03-13 at 1 58 49 PM" src="https://user-images.githubusercontent.com/59851451/158079414-5a12ee72-f37f-4f3c-885c-62bdaeee787c.png">

The above two images showcase the sell function
