### PR TITLE
Buy and Sell endpoints with tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -146,7 +146,7 @@ public class CommonsController extends ApiController {
     UserCommons uc = UserCommons.builder()
         .commonsId(commonsId)
         .userId(userId)
-        .totalWealth(100)
+        .totalWealth(0)
         .build();
 
     userCommonsRepository.save(uc);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -146,7 +146,7 @@ public class CommonsController extends ApiController {
     UserCommons uc = UserCommons.builder()
         .commonsId(commonsId)
         .userId(userId)
-        .totalWealth(0)
+        .totalWealth(100)
         .build();
 
     userCommonsRepository.save(uc);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -12,12 +12,21 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+
+import org.springframework.http.ResponseEntity;
+import javax.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Api(description = "User Commons")
 @RequestMapping("/api/usercommons")
@@ -26,6 +35,9 @@ public class UserCommonsController extends ApiController {
 
   @Autowired
   private UserCommonsRepository userCommonsRepository;
+
+  @Autowired
+  private CommonsRepository commonsRepository;
 
   @Autowired
   ObjectMapper mapper;
@@ -56,5 +68,57 @@ public class UserCommonsController extends ApiController {
             () -> new EntityNotFoundException(UserCommons.class, "commonsId", commonsId, "userId", userId));
     return userCommons;
   }
+
+  @ApiOperation(value = "Buy a cow, totalWealth updated")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @PutMapping("/buy")
+  public ResponseEntity<String> putUserCommonsByIdBuy(
+          @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
+
+        User u = getCurrentUser().getUser();
+        Long userId = u.getId();
+
+        Commons commons = commonsRepository.findById(commonsId).orElseThrow( 
+          ()->new EntityNotFoundException(Commons.class, commonsId));
+        UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)
+        .orElseThrow(
+            () -> new EntityNotFoundException(UserCommons.class, "commonsId", commonsId, "userId", userId));
+
+        if(userCommons.getTotalWealth() >= commons.getCowPrice() ){
+          userCommons.setTotalWealth(userCommons.getTotalWealth() - commons.getCowPrice());
+          userCommons.setNumOfCows(userCommons.getNumOfCows() + 1);
+        }
+        userCommonsRepository.save(userCommons);
+
+        String body = mapper.writeValueAsString(userCommons);
+        return ResponseEntity.ok().body(body);
+    }
+
+  @ApiOperation(value = "Sell a cow, totalWealth updated")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @PutMapping("/sell")
+  public ResponseEntity<String> putUserCommonsByIdSell(
+          @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
+        User u = getCurrentUser().getUser();
+        Long userId = u.getId();
+
+        Commons commons = commonsRepository.findById(commonsId).orElseThrow( 
+          ()->new EntityNotFoundException(Commons.class, commonsId));
+        UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)
+        .orElseThrow(
+            () -> new EntityNotFoundException(UserCommons.class, "commonsId", commonsId, "userId", userId));
+
+
+        if(userCommons.getNumOfCows() >= 1 ){
+          userCommons.setTotalWealth(userCommons.getTotalWealth() + commons.getCowPrice());
+          userCommons.setNumOfCows(userCommons.getNumOfCows() - 1);
+        }
+        userCommonsRepository.save(userCommons);
+
+        String body = mapper.writeValueAsString(userCommons);
+        return ResponseEntity.ok().body(body);
+    }
+
+    
 
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
@@ -26,7 +26,7 @@ public class UserCommons {
   @Column(name="user_id")
   private long userId;  
 
-  private int totalWealth;
+  private double totalWealth;
 
   private int numOfCows;
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -37,6 +37,8 @@ import java.util.Optional;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.time.LocalDateTime;
+
 @WebMvcTest(controllers = UserCommonsController.class)
 public class UserCommonsControllerTests extends ControllerTestCase {
 
@@ -128,4 +130,520 @@ public class UserCommonsControllerTests extends ControllerTestCase {
     Map<String, Object> jsonResponse = responseToJson(response);
     assertEquals(expectedJson, jsonResponse);
   }
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void test_BuyCow_commons_exists() throws Exception {
+  
+      // arrange
+  
+      UserCommons origUserCommons = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300)
+      .numOfCows(1)
+      .build();
+  
+      Commons randomCommons = Commons
+      .builder()
+      .name("test commons")
+      .cowPrice(10)
+      .milkPrice(2)
+      .startingBalance(300)
+      .startingDate(LocalDateTime.now())
+      .build();
+  
+      UserCommons userCommonsToSend = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300)
+      .numOfCows(1)
+      .build();
+  
+      UserCommons correctuserCommons = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300-randomCommons.getCowPrice())
+      .numOfCows(2)
+      .build();
+  
+      String requestBody = mapper.writeValueAsString(userCommonsToSend);
+      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+  
+      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(randomCommons));
+  
+      // act
+      MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1")
+          .contentType(MediaType.APPLICATION_JSON)
+                      .characterEncoding("utf-8")
+                      .content(requestBody)
+                      .with(csrf()))
+              .andExpect(status().isOk()).andReturn();
+  
+      // assert
+      verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+      verify(userCommonsRepository, times(1)).save(correctuserCommons);
+      String responseString = response.getResponse().getContentAsString();
+      assertEquals(expectedReturn, responseString);
+  }
+  
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void test_SellCow_commons_exists() throws Exception {
+  
+      // arrange
+  
+      UserCommons origUserCommons = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300)
+      .numOfCows(1)
+      .build();
+  
+      Commons randomCommons = Commons
+      .builder()
+      .name("test commons")
+      .cowPrice(10)
+      .milkPrice(2)
+      .startingBalance(300)
+      .startingDate(LocalDateTime.now())
+      .build();
+  
+      UserCommons userCommonsToSend = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300)
+      .numOfCows(1)
+      .build();
+  
+      UserCommons correctuserCommons = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300+randomCommons.getCowPrice())
+      .numOfCows(0)
+      .build();
+  
+      String requestBody = mapper.writeValueAsString(userCommonsToSend);
+      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+  
+      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(randomCommons));
+  
+      // act
+      MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=1")
+          .contentType(MediaType.APPLICATION_JSON)
+                      .characterEncoding("utf-8")
+                      .content(requestBody)
+                      .with(csrf()))
+              .andExpect(status().isOk()).andReturn();
+  
+      // assert
+      verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+      verify(userCommonsRepository, times(1)).save(correctuserCommons);
+      String responseString = response.getResponse().getContentAsString();
+      assertEquals(expectedReturn, responseString);
+  }
+  
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void test_BuyCow_commons_for_user_DOES_NOT_exist() throws Exception {
+  
+      // arrange
+  
+      UserCommons origUserCommons = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300)
+      .numOfCows(1)
+      .build();
+  
+      Commons randomCommons = Commons
+      .builder()
+      .name("test commons")
+      .cowPrice(10)
+      .milkPrice(2)
+      .startingBalance(300)
+      .startingDate(LocalDateTime.now())
+      .build();
+  
+      UserCommons userCommonsToSend = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300)
+      .numOfCows(1)
+      .build();
+  
+      UserCommons correctuserCommons = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300-randomCommons.getCowPrice())
+      .numOfCows(2)
+      .build();
+  
+      String requestBody = mapper.writeValueAsString(userCommonsToSend);
+      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+  
+      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+      when(commonsRepository.findById(eq(234L))).thenReturn(Optional.of(randomCommons));
+  
+      // act
+      MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=234") 
+          .contentType(MediaType.APPLICATION_JSON)
+                      .characterEncoding("utf-8")
+                      .content(requestBody)
+                      .with(csrf()))
+              .andExpect(status().is(404)).andReturn();
+  
+      // assert
+  
+      String responseString = response.getResponse().getContentAsString();
+      String expectedString = "{\"message\":\"UserCommons with commonsId 234 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
+      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+      Map<String, Object> jsonResponse = responseToJson(response);
+      assertEquals(expectedJson, jsonResponse);
+  }
+  
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void test_SellCow_commons_for_usercommons_DOES_NOT_exist() throws Exception {
+  
+      // arrange
+  
+      UserCommons origUserCommons = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300)
+      .numOfCows(1)
+      .build();
+  
+      Commons randomCommons = Commons
+      .builder()
+      .id(234L)
+      .name("test commons")
+      .cowPrice(10)
+      .milkPrice(2)
+      .startingBalance(300)
+      .startingDate(LocalDateTime.now())
+      .build();
+  
+      UserCommons userCommonsToSend = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300)
+      .numOfCows(1)
+      .build();
+  
+      UserCommons correctuserCommons = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300+randomCommons.getCowPrice())
+      .numOfCows(2)
+      .build();
+  
+      String requestBody = mapper.writeValueAsString(userCommonsToSend);
+      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+  
+      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+      when(commonsRepository.findById(eq(234L))).thenReturn(Optional.of(randomCommons));
+  
+      // act
+      MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=234")
+          .contentType(MediaType.APPLICATION_JSON)
+                      .characterEncoding("utf-8")
+                      .content(requestBody)
+                      .with(csrf()))
+              .andExpect(status().is(404)).andReturn();
+  
+      // assert
+      String responseString = response.getResponse().getContentAsString();
+      String expectedString = "{\"message\":\"UserCommons with commonsId 234 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
+      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+      Map<String, Object> jsonResponse = responseToJson(response);
+      assertEquals(expectedJson, jsonResponse);
+  }
+  
+  //tests for when the common itself doesn't exist
+  
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void test_SellCow_commons_DOES_NOT_exist() throws Exception {
+  
+      // arrange
+  
+      UserCommons origUserCommons = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300)
+      .numOfCows(1)
+      .build();
+  
+      Commons randomCommons = Commons
+      .builder()
+      .name("test commons")
+      .cowPrice(10)
+      .milkPrice(2)
+      .startingBalance(300)
+      .startingDate(LocalDateTime.now())
+      .build();
+  
+      UserCommons userCommonsToSend = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300)
+      .numOfCows(1)
+      .build();
+  
+      UserCommons correctuserCommons = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300+randomCommons.getCowPrice())
+      .numOfCows(2)
+      .build();
+  
+      String requestBody = mapper.writeValueAsString(userCommonsToSend);
+      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+  
+      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(randomCommons));
+  
+      // act
+      MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=222")
+          .contentType(MediaType.APPLICATION_JSON)
+                      .characterEncoding("utf-8")
+                      .content(requestBody)
+                      .with(csrf()))
+              .andExpect(status().is(404)).andReturn();
+  
+      // assert
+      String responseString = response.getResponse().getContentAsString();
+      String expectedString = "{\"message\":\"Commons with id 222 not found\",\"type\":\"EntityNotFoundException\"}";
+      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+      Map<String, Object> jsonResponse = responseToJson(response);
+      assertEquals(expectedJson, jsonResponse);
+  }
+  
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void test_BuyCow_commons_DOES_NOT_exist() throws Exception {
+  
+      // arrange
+  
+      UserCommons origUserCommons = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300)
+      .numOfCows(1)
+      .build();
+  
+      Commons randomCommons = Commons
+      .builder()
+      .name("test commons")
+      .cowPrice(10)
+      .milkPrice(2)
+      .startingBalance(300)
+      .startingDate(LocalDateTime.now())
+      .build();
+  
+      UserCommons userCommonsToSend = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300)
+      .numOfCows(1)
+      .build();
+  
+      UserCommons correctuserCommons = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300+randomCommons.getCowPrice())
+      .numOfCows(2)
+      .build();
+  
+      String requestBody = mapper.writeValueAsString(userCommonsToSend);
+      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+  
+      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(randomCommons));
+  
+      // act
+      MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=222")
+          .contentType(MediaType.APPLICATION_JSON)
+                      .characterEncoding("utf-8")
+                      .content(requestBody)
+                      .with(csrf()))
+              .andExpect(status().is(404)).andReturn();
+  
+      // assert
+      String responseString = response.getResponse().getContentAsString();
+      String expectedString = "{\"message\":\"Commons with id 222 not found\",\"type\":\"EntityNotFoundException\"}";
+      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+      Map<String, Object> jsonResponse = responseToJson(response);
+      assertEquals(expectedJson, jsonResponse);
+  }
+  
+  
+  
+  // Put tests for edge cases (not enough money to buy, or no cow to sell)
+  
+  
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void test_BuyCow_commons_exists_not_enough_money() throws Exception {
+  
+      // arrange
+  
+      UserCommons origUserCommons = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(0)
+      .numOfCows(1)
+      .build();
+  
+      Commons randomCommons = Commons
+      .builder()
+      .name("test commons")
+      .cowPrice(10)
+      .milkPrice(2)
+      .startingBalance(0)
+      .startingDate(LocalDateTime.now())
+      .build();
+  
+      UserCommons userCommonsToSend = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(0)
+      .numOfCows(1)
+      .build();
+  
+      UserCommons correctuserCommons = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(0)
+      .numOfCows(1)
+      .build();
+  
+      String requestBody = mapper.writeValueAsString(userCommonsToSend);
+      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+  
+      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(randomCommons));
+  
+      // act
+      MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1")
+          .contentType(MediaType.APPLICATION_JSON)
+                      .characterEncoding("utf-8")
+                      .content(requestBody)
+                      .with(csrf()))
+              .andExpect(status().isOk()).andReturn();
+  
+      // assert
+      verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+      verify(userCommonsRepository, times(1)).save(correctuserCommons);
+      String responseString = response.getResponse().getContentAsString();
+      assertEquals(expectedReturn, responseString);
+  }
+  
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void test_SellCow_commons_exists_no_cow_to_sell() throws Exception {
+  
+      // arrange
+  
+      UserCommons origUserCommons = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300)
+      .numOfCows(0)
+      .build();
+  
+      Commons randomCommons = Commons
+      .builder()
+      .name("test commons")
+      .cowPrice(10)
+      .milkPrice(2)
+      .startingBalance(300)
+      .startingDate(LocalDateTime.now())
+      .build();
+  
+      UserCommons userCommonsToSend = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300)
+      .numOfCows(0)
+      .build();
+  
+      UserCommons correctuserCommons = UserCommons
+      .builder()
+      .id(1L)
+      .userId(1L)
+      .commonsId(1L)
+      .totalWealth(300)
+      .numOfCows(0)
+      .build();
+  
+      String requestBody = mapper.writeValueAsString(userCommonsToSend);
+      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+  
+      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(randomCommons));
+  
+      // act
+      MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=1")
+          .contentType(MediaType.APPLICATION_JSON)
+                      .characterEncoding("utf-8")
+                      .content(requestBody)
+                      .with(csrf()))
+              .andExpect(status().isOk()).andReturn();
+  
+      // assert
+      verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+      verify(userCommonsRepository, times(1)).save(correctuserCommons);
+      String responseString = response.getResponse().getContentAsString();
+      assertEquals(expectedReturn, responseString);
+    }
 }


### PR DESCRIPTION
# Overview

In UserCommonsController.java, endpoints for Buy and Sell buttons have been added. When the Buy endpoint is called, the Total Wealth decreases by Cow Price, and the number of cows increases by one. When the Sell endpoint is called, the Total Wealth increases by Cow Price, and the number of cows decreases by one.

The UserCommonsControllerTests.java file now contains tests for these two endpoints and all backend tests pass. Tests include: buying/selling a cow when commons exists, buying/selling a cow when the commons for user does not exist, buying/selling a cow when the commons does not exist, and finally tests the edge cases of buying a cow when you do not have enough money (you will not be able to) or attempting to sell a cow when you have none (you will not be able to).

Note that if you do not set the total wealth and number of cows through Swagger to numbers specified in the Testing Plan, they will be initialized to 0 and you will be unable to do anything -- this will be addressed in a separate PR which will edit the CommonsController.java file.

# Issues Addressed

This PR addresses issues #14 an #15. Also starts and completes issue #49.

# Details

Current Commons (2 Cows, Total Wealth = $80, Market Cow Price: $20)
![image](https://user-images.githubusercontent.com/69827289/158277845-9f1fe515-415f-4460-9d43-facfe45c1607.png)

Buy One Cow Endpoint Working in Swagger:

![image](https://user-images.githubusercontent.com/69827289/158277988-b3edbe65-60f1-46d5-a738-c298b772c05b.png)

Total Wealth and NumOfCows updated on Play Page:

![image](https://user-images.githubusercontent.com/69827289/158278062-4e282050-605d-471c-b45f-bd03436034a2.png)

Sell One Cow Endpoint Working in Swagger:
![image](https://user-images.githubusercontent.com/69827289/158278117-fa62fcd9-a3be-46de-b4e3-4c493a238a23.png)

Total Wealth and NumOfCows updated on Play Page:

![image](https://user-images.githubusercontent.com/69827289/158278155-64c3389e-87c1-487d-a41d-3531e4f9f68d.png)

# Testing Plan

1. Create and join a commons.
2. On swagger-ui, go to the buy endpoint. Fill out all ids with 1. Set the total wealth to a number greater than 10 and the number of cows to a number greater than 1. Then, execute and notice that on the webpage, the total wealth and number of cows changes accordingly. 
3. Do the same for the sell endpoint.
4. Note that if you attempt to sell a cow but have no cows you will be unable to, and that you will be unable to buy a cow if your total wealth is $0. If you do not set the total wealth and number of cows to numbers specified above, they will be initialized to 0 and you will be unable to do anything -- this will be addressed in a separate PR which will edit the CommonsController.java file.


